### PR TITLE
feat: add CI/release automation, modernize image, prepare for public release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+*.md
+*.yaml
+LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - flavor: ubuntu
+            base_image: ubuntu:24.04
+          - flavor: debian
+            base_image: debian:13-slim
+    name: verify (${{ matrix.flavor }})
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -36,12 +45,13 @@ jobs:
           context: .
           file: ./Dockerfile
           target: base
+          build-args: BASE_IMAGE=${{ matrix.base_image }}
           platforms: linux/amd64
           push: false
           load: true
           tags: docker-my-tools:ci-base
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}
 
       - name: Build ai image (linux/amd64)
         uses: docker/build-push-action@v7
@@ -49,12 +59,13 @@ jobs:
           context: .
           file: ./Dockerfile
           target: ai
+          build-args: BASE_IMAGE=${{ matrix.base_image }}
           platforms: linux/amd64
           push: false
           load: true
           tags: docker-my-tools:ci-ai
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}
 
       - name: Smoke test base image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
             helm version
             stern --version
             node --version
+            claude --version
+            codex --version
+            opencode --version
+            tmux -V
             psql --version
             redis-cli --version
             kcat -V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+# Verification gate. Lints the Dockerfile, builds the image (linux/amd64 only -
+# emulated arm64 builds are too slow for PR feedback; the release build covers
+# both arches), and smoke-tests the bundled tools on every pull request and on
+# every push to `main`. Merging to `main` only runs CI; it never cuts a release
+# (releases are handled separately, on a schedule, by release.yml).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.5.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: docker-my-tools:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test bundled tools
+        run: |
+          docker run --rm docker-my-tools:ci bash -euxc '
+            kubectl version --client
+            helm version
+            stern --version
+            node --version
+            psql --version
+            redis-cli --version
+            kcat -V
+            kafkacat -V
+            dig -v
+            ping -V
+            curl --version
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build image (linux/amd64)
+      - name: Build base image (linux/amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
+          target: base
           platforms: linux/amd64
           push: false
           load: true
-          tags: docker-my-tools:ci
+          tags: docker-my-tools:ci-base
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke test bundled tools
+      - name: Build ai image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: ai
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: docker-my-tools:ci-ai
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test base image
         run: |
-          docker run --rm docker-my-tools:ci bash -euxc '
+          docker run --rm docker-my-tools:ci-base bash -euxc '
             kubectl version --client
             helm version
             stern --version
-            node --version
-            claude --version
-            codex --version
-            opencode --version
             tmux -V
             psql --version
             redis-cli --version
@@ -60,4 +70,14 @@ jobs:
             dig -v
             ping -V
             curl --version
+          '
+
+      - name: Smoke test ai image
+        run: |
+          docker run --rm docker-my-tools:ci-ai bash -euxc '
+            node --version
+            claude --version
+            codex --version
+            opencode --version
+            kubectl version --client
           '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,8 @@ jobs:
           MINOR="${VERSION#*.}"; MINOR="${MINOR%%.*}"
           {
             echo "image=$IMAGE"
-            echo "tags=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
+            echo "tags_base=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
+            echo "tags_ai=$IMAGE:$VERSION-ai,$IMAGE:$MAJOR.$MINOR-ai,$IMAGE:$MAJOR-ai,$IMAGE:latest-ai"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
@@ -105,15 +106,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build and push base image
         if: steps.tag.outputs.new_version
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
+          target: base
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags_base }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push ai image
+        if: steps.tag.outputs.new_version
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: ai
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags_ai }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,11 @@ jobs:
           MINOR="${VERSION#*.}"; MINOR="${MINOR%%.*}"
           {
             echo "image=$IMAGE"
+            # Ubuntu is the default flavor (unsuffixed tags); Debian gets -debian
             echo "tags_base=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
             echo "tags_ai=$IMAGE:$VERSION-ai,$IMAGE:$MAJOR.$MINOR-ai,$IMAGE:$MAJOR-ai,$IMAGE:latest-ai"
+            echo "tags_debian_base=$IMAGE:$VERSION-debian,$IMAGE:$MAJOR.$MINOR-debian,$IMAGE:$MAJOR-debian,$IMAGE:latest-debian"
+            echo "tags_debian_ai=$IMAGE:$VERSION-debian-ai,$IMAGE:$MAJOR.$MINOR-debian-ai,$IMAGE:$MAJOR-debian-ai,$IMAGE:latest-debian-ai"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
@@ -106,13 +109,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push base image
+      - name: Build and push base image (ubuntu)
         if: steps.tag.outputs.new_version
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           target: base
+          build-args: BASE_IMAGE=ubuntu:24.04
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags_base }}
@@ -120,16 +124,17 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ubuntu
+          cache-to: type=gha,mode=max,scope=ubuntu
 
-      - name: Build and push ai image
+      - name: Build and push ai image (ubuntu)
         if: steps.tag.outputs.new_version
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           target: ai
+          build-args: BASE_IMAGE=ubuntu:24.04
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags_ai }}
@@ -137,8 +142,44 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ubuntu
+          cache-to: type=gha,mode=max,scope=ubuntu
+
+      - name: Build and push base image (debian)
+        if: steps.tag.outputs.new_version
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: base
+          build-args: BASE_IMAGE=debian:13-slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags_debian_base }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
+          cache-from: type=gha,scope=debian
+          cache-to: type=gha,mode=max,scope=debian
+
+      - name: Build and push ai image (debian)
+        if: steps.tag.outputs.new_version
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: ai
+          build-args: BASE_IMAGE=debian:13-slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags_debian_ai }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
+          cache-from: type=gha,scope=debian
+          cache-to: type=gha,mode=max,scope=debian
 
       - name: Create GitHub release
         if: steps.tag.outputs.new_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+# Releases are NOT cut on merge to main - pushes to main only run CI (ci.yml).
+# Instead this job runs on a schedule (monthly): it determines the next
+# version from the Conventional Commits since the last tag. Only if there is a
+# release-worthy change (a feat/fix/breaking-change commit) does it create the
+# git tag, build and push the multi-arch image to the GitHub Container
+# Registry (ghcr.io), and cut a GitHub Release. If nothing releasable has landed
+# since the last tag, `new_version` is empty and every release step is skipped -
+# a no-op run.
+#
+# To FORCE a release (e.g. after a docs-only or chore change), trigger it
+# manually and pick a bump level:
+#   * GitHub UI: Actions > Release > "Run workflow" > set "bump" to patch/minor/major.
+#   * CLI:       gh workflow run release.yml -f bump=patch
+# With `bump=auto` (the default) a manual run behaves exactly like the schedule:
+# it releases only if a feat/fix/breaking-change commit has landed.
+#
+# Version bump rules (mathieudutour/github-tag-action, Conventional Commits):
+#   - commit/PR title contains "BREAKING CHANGE" or "feat!:" -> major (x.0.0)
+#   - commit/PR title starts with "feat:"                    -> minor (0.x.0)
+#   - commit/PR title starts with "fix:"                     -> patch (0.0.x)
+#   - anything else                                          -> no release (skipped)
+
+on:
+  schedule:
+    - cron: "0 5 1 * *" # monthly (first of the month, 05:00 UTC)
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Force a release with this bump when no releasable commits exist (auto = behave like the schedule)"
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
+
+# Never run two releases at once.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create/push the git tag + release
+  packages: write # push the image to ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          # Full history is required so the tagging action can read previous tags
+          # and compute the next semantic version.
+          fetch-depth: 0
+
+      - name: Determine next version
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+          # `default_bump` is the bump applied only when NO Conventional Commit
+          # since the last tag dictates one. Normally `false`, so non-releasable
+          # commits (docs, test, ci, chore, ...) leave `new_version` empty and
+          # the release is skipped. A manual run can override it: passing
+          # bump=patch|minor|major forces that bump even on a docs-only change.
+          # A feat/fix/breaking-change commit always wins over this fallback.
+          default_bump: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump != 'auto') && inputs.bump || false }}
+          release_branches: main
+
+      - name: Compute image metadata
+        if: steps.tag.outputs.new_version
+        id: meta
+        env:
+          VERSION: ${{ steps.tag.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # ghcr.io image names must be lowercase.
+          IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          MAJOR="${VERSION%%.*}"
+          MINOR="${VERSION#*.}"; MINOR="${MINOR%%.*}"
+          {
+            echo "image=$IMAGE"
+            echo "tags=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        if: steps.tag.outputs.new_version
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        if: steps.tag.outputs.new_version
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: steps.tag.outputs.new_version
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        if: steps.tag.outputs.new_version
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub release
+        if: steps.tag.outputs.new_version
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          name: ${{ steps.tag.outputs.new_tag }}
+          body: ${{ steps.tag.outputs.changelog }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,4 +1,7 @@
 # DL3008: pinning every apt package version is not practical for a debug
 # toolbox image; the base image and tool binaries are pinned instead.
+# DL3016: the AI CLIs (claude-code, codex, opencode) release very frequently;
+# leaving them unpinned lets the monthly release pick up current versions.
 ignored:
   - DL3008
+  - DL3016

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+# DL3008: pinning every apt package version is not practical for a debug
+# toolbox image; the base image and tool binaries are pinned instead.
+ignored:
+  - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # Two build targets:
 #   base — slim debug toolbox (network, DB, Kafka, and Kubernetes CLI tools)
 #   ai   — base plus Node.js and the Claude Code / Codex / opencode CLIs
-FROM ubuntu:24.04 AS base
+#
+# BASE_IMAGE selects the OS flavor; ubuntu:24.04 (LTS) and debian:13-slim
+# are both supported — the package list below exists in both.
+ARG BASE_IMAGE=ubuntu:24.04
+
+FROM ${BASE_IMAGE} AS base
 
 LABEL org.opencontainers.image.source="https://github.com/diogopms/docker-my-tools" \
       org.opencontainers.image.description="In-cluster debug toolbox: network, database, Kafka, and Kubernetes CLI tools" \
@@ -50,7 +55,7 @@ FROM base AS ai
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         postgresql-client \
         redis-tools \
         telnet \
+        tmux \
     # kafkacat was renamed to kcat; keep the old name working
     && ln -s /usr/bin/kcat /usr/local/bin/kafkacat \
     && rm -rf /var/lib/apt/lists/*
@@ -30,6 +31,9 @@ RUN apt-get update \
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && npm cache clean --force
 
 RUN curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
         -o /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:13-slim
+# Two build targets:
+#   base — slim debug toolbox (network, DB, Kafka, and Kubernetes CLI tools)
+#   ai   — base plus Node.js and the Claude Code / Codex / opencode CLIs
+FROM ubuntu:24.04 AS base
 
 LABEL org.opencontainers.image.source="https://github.com/diogopms/docker-my-tools" \
       org.opencontainers.image.description="In-cluster debug toolbox: network, database, Kafka, and Kubernetes CLI tools" \
@@ -28,13 +31,6 @@ RUN apt-get update \
     && ln -s /usr/bin/kcat /usr/local/bin/kafkacat \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
-    && npm cache clean --force
-
 RUN curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
         -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
@@ -46,5 +42,17 @@ RUN curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.ta
 
 RUN curl -fsSL "https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz" \
         | tar -xz -C /usr/local/bin stern
+
+CMD ["bash"]
+
+
+FROM base AS ai
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai \
+    && npm cache clean --force
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ CMD ["bash"]
 
 FROM base AS ai
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,46 @@
-FROM debian:stable-slim
-LABEL Diogo Serrano <info@diogoserrano.com>
+FROM debian:13-slim
 
-RUN apt-get update;
-RUN apt-get -y install iputils-ping telnet postgresql redis curl htop kafkacat;
+LABEL org.opencontainers.image.source="https://github.com/diogopms/docker-my-tools" \
+      org.opencontainers.image.description="In-cluster debug toolbox: network, database, Kafka, and Kubernetes CLI tools" \
+      org.opencontainers.image.licenses="MIT"
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh
-RUN chmod +x /tmp/nodesource_setup.sh
-RUN /tmp/nodesource_setup.sh
+# Set automatically by buildx from --platform (amd64 / arm64).
+ARG TARGETARCH
+ARG KUBECTL_VERSION=1.36.4
+ARG HELM_VERSION=3.21.4
+ARG STERN_VERSION=1.34.0
 
-RUN apt-get -y install -y nodejs
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-RUN chmod 700 get_helm.sh
-RUN ./get_helm.sh
-RUN rm get_helm.sh
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dnsutils \
+        htop \
+        iputils-ping \
+        kcat \
+        postgresql-client \
+        redis-tools \
+        telnet \
+    # kafkacat was renamed to kcat; keep the old name working
+    && ln -s /usr/bin/kcat /usr/local/bin/kafkacat \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/linux/amd64/kubectl -o kubectl
-RUN chmod +x ./kubectl; mv ./kubectl /usr/local/bin/kubectl
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 -o stern_linux_amd64
-RUN chmod +x ./stern_linux_amd64; mv ./stern_linux_amd64 /usr/local/bin/stern
+RUN curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+        -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+RUN curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+        | tar -xz -C /tmp \
+    && mv "/tmp/linux-${TARGETARCH}/helm" /usr/local/bin/helm \
+    && rm -rf "/tmp/linux-${TARGETARCH}"
+
+RUN curl -fsSL "https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin stern
+
+CMD ["bash"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Diogo Serrano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ itself without installing anything on the nodes.
 | `redis-cli` (redis-tools) | Redis client |
 | `kcat` (alias `kafkacat`) | Kafka producer/consumer |
 | `node` / `npm` | Node.js runtime |
+| `claude` | Claude Code CLI |
+| `codex` | OpenAI Codex CLI |
+| `opencode` | opencode CLI |
+| `tmux` | Terminal multiplexer |
 | `curl`, `ping`, `telnet`, `dig`/`nslookup` | Network debugging |
 | `htop` | Process viewer |
 
@@ -33,21 +37,52 @@ Tags: `latest`, plus a semver cascade per release (`X.Y.Z`, `X.Y`, `X`).
 
 ## Usage
 
-Run an interactive debug shell in a cluster:
+### One-off interactive shell in a cluster
+
+The pod is created, attached to your terminal, and deleted when you exit:
 
 ```sh
-kubectl run internal-tools --restart=Never -i --tty \
+kubectl run internal-tools --rm --restart=Never -i --tty \
   --image ghcr.io/diogopms/docker-my-tools:latest -- bash
 ```
 
-Or use the provided manifests:
+### Long-running pod (keeps running, exec in when needed)
+
+Deploy it once and keep it available for troubleshooting. The included
+[`deployment.yaml`](deployment.yaml) runs `sleep infinity` so the container
+stays alive and gets rescheduled/restarted automatically if the node or pod
+dies:
+
+```sh
+kubectl apply -f deployment.yaml
+kubectl exec -it deploy/diogopms-my-tools -- bash
+```
+
+Since `tmux` is included, you can also keep sessions alive inside the pod
+across disconnects:
+
+```sh
+kubectl exec -it deploy/diogopms-my-tools -- tmux new -A -s debug
+```
+
+Deploy to a specific namespace and clean up when done:
+
+```sh
+kubectl apply -f deployment.yaml -n ops
+kubectl exec -it deploy/diogopms-my-tools -n ops -- bash
+kubectl delete -f deployment.yaml -n ops
+```
+
+### Single pod (no Deployment controller)
+
+[`pod.yaml`](pod.yaml) starts one interactive pod (not restarted if it dies):
 
 ```sh
 kubectl create -f pod.yaml
 kubectl exec -it diogopms-my-tools -- bash
 ```
 
-Run locally:
+### Run locally
 
 ```sh
 docker run --rm -it ghcr.io/diogopms/docker-my-tools:latest

--- a/README.md
+++ b/README.md
@@ -3,16 +3,21 @@
 [![CI](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml)
 [![Release](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml)
 
-A debug toolbox image for Kubernetes clusters, based on Ubuntu LTS (24.04).
-Spin it up as a throwaway pod to troubleshoot networking, databases, Kafka,
-and the cluster itself without installing anything on the nodes.
+A debug toolbox image for Kubernetes clusters. Spin it up as a throwaway pod
+to troubleshoot networking, databases, Kafka, and the cluster itself without
+installing anything on the nodes.
 
 ## Variants
 
-| Variant | Tags | Contents |
-| --- | --- | --- |
-| **base** | `latest`, `X.Y.Z`, `X.Y`, `X` | Slim debug toolbox (tools below) |
-| **ai** | `latest-ai`, `X.Y.Z-ai`, `X.Y-ai`, `X-ai` | base + Node.js + Claude Code, Codex, and opencode CLIs |
+Two OS flavors (Ubuntu 24.04 LTS is the default; Debian 13 slim tags carry a
+`-debian` suffix) times two tool sets:
+
+| Variant | OS | Tags | Contents |
+| --- | --- | --- | --- |
+| **base** | Ubuntu 24.04 | `latest`, `X.Y.Z`, `X.Y`, `X` | Slim debug toolbox (tools below) |
+| **ai** | Ubuntu 24.04 | `latest-ai`, `X.Y.Z-ai`, `X.Y-ai`, `X-ai` | base + Node.js 24 + Claude Code, Codex, and opencode CLIs |
+| **base** | Debian 13 | `latest-debian`, `X.Y.Z-debian`, … | Same as base |
+| **ai** | Debian 13 | `latest-debian-ai`, `X.Y.Z-debian-ai`, … | Same as ai |
 
 ## Included tools
 
@@ -99,10 +104,14 @@ docker run --rm -it ghcr.io/diogopms/docker-my-tools:latest
 ```sh
 docker build --target base -t docker-my-tools .
 docker build --target ai -t docker-my-tools:ai .
+
+# Debian flavor
+docker build --target base --build-arg BASE_IMAGE=debian:13-slim -t docker-my-tools:debian .
 ```
 
 Tool versions are pinned via build args (`KUBECTL_VERSION`, `HELM_VERSION`,
-`STERN_VERSION`) and can be overridden with `--build-arg`.
+`STERN_VERSION`), and `BASE_IMAGE` selects the OS flavor (`ubuntu:24.04` or
+`debian:13-slim`); override any of them with `--build-arg`.
 
 ## CI & releases
 

--- a/README.md
+++ b/README.md
@@ -3,37 +3,43 @@
 [![CI](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml)
 [![Release](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml)
 
-A small Debian-based debug toolbox image for Kubernetes clusters. Spin it up as
-a throwaway pod to troubleshoot networking, databases, Kafka, and the cluster
-itself without installing anything on the nodes.
+A debug toolbox image for Kubernetes clusters, based on Ubuntu LTS (24.04).
+Spin it up as a throwaway pod to troubleshoot networking, databases, Kafka,
+and the cluster itself without installing anything on the nodes.
+
+## Variants
+
+| Variant | Tags | Contents |
+| --- | --- | --- |
+| **base** | `latest`, `X.Y.Z`, `X.Y`, `X` | Slim debug toolbox (tools below) |
+| **ai** | `latest-ai`, `X.Y.Z-ai`, `X.Y-ai`, `X-ai` | base + Node.js + Claude Code, Codex, and opencode CLIs |
 
 ## Included tools
 
-| Tool | Purpose |
-| --- | --- |
-| `kubectl` | Kubernetes CLI |
-| `helm` | Kubernetes package manager |
-| `stern` | Multi-pod log tailing |
-| `psql` (postgresql-client) | PostgreSQL client |
-| `redis-cli` (redis-tools) | Redis client |
-| `kcat` (alias `kafkacat`) | Kafka producer/consumer |
-| `node` / `npm` | Node.js runtime |
-| `claude` | Claude Code CLI |
-| `codex` | OpenAI Codex CLI |
-| `opencode` | opencode CLI |
-| `tmux` | Terminal multiplexer |
-| `curl`, `ping`, `telnet`, `dig`/`nslookup` | Network debugging |
-| `htop` | Process viewer |
+| Tool | Purpose | Variant |
+| --- | --- | --- |
+| `kubectl` | Kubernetes CLI | base |
+| `helm` | Kubernetes package manager | base |
+| `stern` | Multi-pod log tailing | base |
+| `psql` (postgresql-client) | PostgreSQL client | base |
+| `redis-cli` (redis-tools) | Redis client | base |
+| `kcat` (alias `kafkacat`) | Kafka producer/consumer | base |
+| `tmux` | Terminal multiplexer | base |
+| `curl`, `ping`, `telnet`, `dig`/`nslookup` | Network debugging | base |
+| `htop` | Process viewer | base |
+| `node` / `npm` | Node.js runtime | ai |
+| `claude` | Claude Code CLI | ai |
+| `codex` | OpenAI Codex CLI | ai |
+| `opencode` | opencode CLI | ai |
 
 ## Image
 
 Published to the GitHub Container Registry, for `linux/amd64` and `linux/arm64`:
 
 ```
-ghcr.io/diogopms/docker-my-tools
+ghcr.io/diogopms/docker-my-tools          # base
+ghcr.io/diogopms/docker-my-tools:latest-ai # ai variant
 ```
-
-Tags: `latest`, plus a semver cascade per release (`X.Y.Z`, `X.Y`, `X`).
 
 ## Usage
 
@@ -91,7 +97,8 @@ docker run --rm -it ghcr.io/diogopms/docker-my-tools:latest
 ## Building locally
 
 ```sh
-docker build -t docker-my-tools .
+docker build --target base -t docker-my-tools .
+docker build --target ai -t docker-my-tools:ai .
 ```
 
 Tool versions are pinned via build args (`KUBECTL_VERSION`, `HELM_VERSION`,

--- a/README.md
+++ b/README.md
@@ -1,30 +1,79 @@
-# My docker image tools
+# docker-my-tools
 
-Build:
+[![CI](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/ci.yml)
+[![Release](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml/badge.svg)](https://github.com/diogopms/docker-my-tools/actions/workflows/release.yml)
+
+A small Debian-based debug toolbox image for Kubernetes clusters. Spin it up as
+a throwaway pod to troubleshoot networking, databases, Kafka, and the cluster
+itself without installing anything on the nodes.
+
+## Included tools
+
+| Tool | Purpose |
+| --- | --- |
+| `kubectl` | Kubernetes CLI |
+| `helm` | Kubernetes package manager |
+| `stern` | Multi-pod log tailing |
+| `psql` (postgresql-client) | PostgreSQL client |
+| `redis-cli` (redis-tools) | Redis client |
+| `kcat` (alias `kafkacat`) | Kafka producer/consumer |
+| `node` / `npm` | Node.js runtime |
+| `curl`, `ping`, `telnet`, `dig`/`nslookup` | Network debugging |
+| `htop` | Process viewer |
+
+## Image
+
+Published to the GitHub Container Registry, for `linux/amd64` and `linux/arm64`:
+
 ```
+ghcr.io/diogopms/docker-my-tools
+```
+
+Tags: `latest`, plus a semver cascade per release (`X.Y.Z`, `X.Y`, `X`).
+
+## Usage
+
+Run an interactive debug shell in a cluster:
+
+```sh
+kubectl run internal-tools --restart=Never -i --tty \
+  --image ghcr.io/diogopms/docker-my-tools:latest -- bash
+```
+
+Or use the provided manifests:
+
+```sh
+kubectl create -f pod.yaml
+kubectl exec -it diogopms-my-tools -- bash
+```
+
+Run locally:
+
+```sh
+docker run --rm -it ghcr.io/diogopms/docker-my-tools:latest
+```
+
+## Building locally
+
+```sh
 docker build -t docker-my-tools .
 ```
 
-Create the tag:
-```
-docker tag docker-my-tools:latest docker.io/diogopms/docker-my-tools:latest
-```
+Tool versions are pinned via build args (`KUBECTL_VERSION`, `HELM_VERSION`,
+`STERN_VERSION`) and can be overridden with `--build-arg`.
 
-Push:
-```
-docker push docker.io/diogopms/docker-my-tools:latest
-```
+## CI & releases
 
-## Kubernetes
+- **CI** (`.github/workflows/ci.yml`): every pull request and push to `main`
+  lints the Dockerfile (hadolint), builds the image, and smoke-tests the
+  bundled tools. Merging to `main` never publishes an image.
+- **Release** (`.github/workflows/release.yml`): runs monthly (or manually via
+  *Actions → Release → Run workflow*). The next version is derived from
+  [Conventional Commits](https://www.conventionalcommits.org/) since the last
+  tag (`feat!:`/`BREAKING CHANGE` → major, `feat:` → minor, `fix:` → patch;
+  anything else skips the release). A release creates the git tag, pushes the
+  multi-arch image to ghcr.io, and publishes a GitHub Release with a changelog.
 
-```
-kubectl run internal-tools --restart='Never' -i --tty --image diogopms/docker-my-tools -- bash
-```
+## License
 
-```
-kubectl create -f pod.yaml
-```
-
-```
-kubectl exec -it diogopms-my-tools bash
-```
+[MIT](LICENSE)

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -17,4 +17,9 @@ spec:
       containers:
       - name: my-docker-my-tools
         image: ghcr.io/diogopms/docker-my-tools:latest
-      restartPolicy: Never
+        # Keep the container alive so it can be exec'd into at any time
+        command: ["sleep", "infinity"]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       containers:
       - name: my-docker-my-tools
-        image: docker.io/diogopms/docker-my-tools:latest
+        image: ghcr.io/diogopms/docker-my-tools:latest
       restartPolicy: Never

--- a/pod.yaml
+++ b/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: my-docker-my-tools
-      image: docker.io/diogopms/docker-my-tools:latest
+      image: ghcr.io/diogopms/docker-my-tools:latest
       args:
         - bash
       resources:


### PR DESCRIPTION
## Summary

Refactors the repo from a manually built Docker Hub image into an automated, public-ready project publishing to GitHub Container Registry. CI/release workflows follow the pattern used in radiology-saas (verify on PR/main; scheduled/manual releases driven by Conventional Commits).

### Image variants (multi-stage Dockerfile, Ubuntu 24.04 LTS base)
- **base** (~385MB): slim debug toolbox — kubectl 1.36.4, Helm 3.21.4, stern 1.34.0, psql, redis-cli, kcat (+kafkacat alias), tmux, curl/ping/telnet/dig, htop
- **ai** (~1.5GB): base + Node.js 22 + Claude Code, Codex, and opencode CLIs
- Multi-arch (`linux/amd64` + `linux/arm64`) via `TARGETARCH`; pinned tool versions via build args; OCI labels

### CI (`ci.yml`)
- On every PR and push to main: hadolint, both targets built (amd64, GHA cache), smoke tests asserting every bundled tool runs in its variant

### Release (`release.yml`)
- Monthly cron + manual dispatch with bump override; no release on merge to main
- Conventional Commits determine the semver bump; no-op when nothing releasable
- Pushes both multi-arch variants to `ghcr.io/diogopms/docker-my-tools`: base as `X.Y.Z`/`X.Y`/`X`/`latest`, ai with the same tags suffixed `-ai`
- Creates a GitHub Release with changelog; uses only the built-in `GITHUB_TOKEN`

### Public repo prep
- MIT `LICENSE`, rewritten `README.md` (variants, tools table, usage, release process, badges), `.dockerignore`, hadolint config
- `deployment.yaml` fixed (Deployments reject `restartPolicy: Never`) and made long-running via `sleep infinity` for `kubectl exec`; manifests point at ghcr.io
- README documents one-off debug pods, long-running Deployments, tmux sessions, and local runs

## Testing
- Local builds of both targets (arm64, Apple Silicon): succeed on Ubuntu 24.04.4
- Smoke tests inside both variants: all tools verified (base confirms Node is absent)
- amd64 builds + hadolint run in CI on this PR

## After merge
1. Run the Release workflow manually (`gh workflow run release.yml -f bump=minor`) to cut the first version and push the first images
2. Set the ghcr.io package visibility to public (Packages -> docker-my-tools -> settings)
3. Flip the repo to public